### PR TITLE
echo not needed when calling phpinfo()

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -1,3 +1,2 @@
 <?php
-echo phpinfo();
-
+phpinfo();


### PR DESCRIPTION
If you call `phpinfo();`, en echo is not needed.
According https://secure.php.net/manual/en/function.phpinfo.php `phpinfo` returns a boolean.
But `phpinfo` has side effects by outputting the according html automatically.